### PR TITLE
Update user agent for avoiding CAPTCHAs

### DIFF
--- a/src/constant/GOOGLE_CONSTANT.ts
+++ b/src/constant/GOOGLE_CONSTANT.ts
@@ -11,7 +11,7 @@ const GOOGLE_CONSTANT = {
   },
   headers: {
     "User-Agent":
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36 Edg/121.0.0.0",
+      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
   },
 };
 


### PR DESCRIPTION
I updated the User-Agent because the previous user agent could lead to either a sorry/index page with a CAPTCHA or a page without JavaScript for legacy browsers that isn't compatible with this scraper. This probably happens due to the typo in "Edg" and when there weren't a lot of requests to Google from the client's IP address before using this scraper.
(It would be nice to support also that type of pages, however that type of pages provides low-resolution gstatic urls. [Here's a link to a sample.](https://files.catbox.moe/q7ditr.html))